### PR TITLE
correction: the last hash example

### DIFF
--- a/Chapter01.md
+++ b/Chapter01.md
@@ -91,7 +91,7 @@ blockchain=hashchain(data_list,IV)
  
  # 最終ハッシュ値
 lasthash=Digest::SHA256.hexdigest(blockchain[-1])
-=> "9af15b336e6a9619928537df30b2e6a2376569fcf9d7e773eccede65606529a0"
+=> "9455075057982b2d43c6fcaa9e5e75058efd43a21107f67526515face5c48365"
 ```
 
 ### 3. ハッシュチェーンと最終データのハッシュ値を入力とし，IV="0000" として，ハッシュチェーンの正統性を検証するプログラムを作成してください。


### PR DESCRIPTION
lasthash should be `9455075057982b2d43c6fcaa9e5e75058efd43a21107f67526515face5c48365`

verified with the code below:
```
require 'digest'
p Digest::SHA256.hexdigest("0004:43371bcb864782ec393fa830eae758ad1e2b172989e8763074fa7a576a8cfe55")
```

とても素敵な本を執筆くださりありがとうございます。
課題の解答例の中で、 `lasthash` の値が hashchain の最後の要素ではなく、`"0000"` の sha256 hash になっていた部分がありましたので、正しい出力例に修正する pull request を出しました。